### PR TITLE
fix: example README import

### DIFF
--- a/example/App.vue
+++ b/example/App.vue
@@ -11,6 +11,6 @@
 
 <script setup lang='ts'>
 import { ref } from 'vue'
-import ComponentA from './README.md'
+import ComponentA from '../README.md'
 const current = ref()
 </script>


### PR DESCRIPTION
The example is currently not working, because it tries to import `example/./README.md`

I guess it should import `../README.md` instead.