### PR TITLE
refactor: use `trimStart` instead of `trimLeft`

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -51,7 +51,7 @@ export function createMarkdown(options: ResolvedOptions) {
   return (id: string, raw: string) => {
     const { wrapperClasses, wrapperComponent, transforms, headEnabled, frontmatterPreprocess } = options
 
-    raw = raw.trimLeft()
+    raw = raw.trimStart()
 
     if (transforms.before)
       raw = transforms.before(raw, id)


### PR DESCRIPTION
We can use `trimStart` instead of `trimLeft`.

![image](https://user-images.githubusercontent.com/25154432/145678972-2c377bce-25c6-4d7d-bad5-22f3eabe2bc7.png)
