### PR TITLE
feat: export frontmatter as named exports

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -82,10 +82,14 @@ export function createMarkdown(options: ResolvedOptions) {
     html = customBlocks.html
 
     const scriptLines: string[] = []
+    let frontmatterExportsLines: string[] = []
 
     if (options.frontmatter) {
       const { head, frontmatter } = frontmatterPreprocess(data || {}, options)
+
       scriptLines.push(`const frontmatter = ${JSON.stringify(frontmatter)}`)
+
+      frontmatterExportsLines = Object.entries(frontmatter).map(([key, value]) => `export const ${key} = ${JSON.stringify(value)}`)
 
       if (!isVue2 && options.exposeFrontmatter && !defineExposeRE.test(hoistScripts.scripts.join('')))
         scriptLines.push('defineExpose({ frontmatter })')
@@ -100,8 +104,8 @@ export function createMarkdown(options: ResolvedOptions) {
     scriptLines.push(...hoistScripts.scripts)
 
     const scripts = isVue2
-      ? `<script>\n${scriptLines.join('\n')}\nexport default { data() { return { frontmatter } } }\n</script>`
-      : `<script setup>\n${scriptLines.join('\n')}\n</script>`
+      ? `<script>\n${scriptLines.join('\n')}\n${frontmatterExportsLines.join('\n')}\nexport default { data() { return { frontmatter } } }\n</script>`
+      : `<script setup>\n${scriptLines.join('\n')}\n</script>${frontmatterExportsLines.length ? `\n<script>\n${frontmatterExportsLines.join('\n')}\n</script>` : ''}`
 
     const sfc = `<template>${html}</template>\n${scripts}\n${customBlocks.blocks.join('\n')}\n`
 

--- a/test/__snapshots__/transform.test.ts.snap
+++ b/test/__snapshots__/transform.test.ts.snap
@@ -12,6 +12,9 @@ exports[`transform > basic 1`] = `
 const frontmatter = {\\"title\\":\\"Hey\\"}
 defineExpose({ frontmatter })
 </script>
+<script>
+export const title = \\"Hey\\"
+</script>
 
 "
 `;
@@ -24,6 +27,9 @@ const frontmatter = {\\"title\\":\\"Hey\\"}
 
 defineExpose({ test: 'test'})
 
+</script>
+<script>
+export const title = \\"Hey\\"
 </script>
 
 "
@@ -49,6 +55,9 @@ exports[`transform > exposes frontmatter 1`] = `
 const frontmatter = {\\"title\\":\\"Hey\\"}
 defineExpose({ frontmatter })
 </script>
+<script>
+export const title = \\"Hey\\"
+</script>
 
 "
 `;
@@ -60,6 +69,9 @@ exports[`transform > frontmatter interpolation 1`] = `
 <script setup>
 const frontmatter = {\\"name\\":\\"My Cool App\\"}
 defineExpose({ frontmatter })
+</script>
+<script>
+export const name = \\"My Cool App\\"
 </script>
 
 "


### PR DESCRIPTION
Hi, 
this should fix #41, fix #38 and fix #24.

This exports each of the frontmatter properties as named export.

So for:
```markdown
---
title: Hey
titleClass: bar
---

# Hello

- A
- B
- C
```

You will be able to do:
```vue
<script setup>
	import MyComp, { title, titleClass } from './my-comp.md'
</script>
<template>
	<h1 :class="titleClass">{{ title }}</h1>
	<MyComp />
</template>
```

Little example of before/after diff: 

```diff
 <script setup lang="ts">
-import PrestationsContent from '../data/prestations.md'
-import {ref, computed} from 'vue'
+import PrestationsContent, { prestations, title } from '../data/prestations.md'
 
-const prestationsRef = ref()
-const prestations = computed(() => prestationsRef.value?.frontmatter.prestations)
-const title = computed(() => prestationsRef.value?.frontmatter.title)
 </script>
 <template>
 <h2
   class="text-3xl font-extrabold text-gray-900 tracking-tight sm:text-4xl"
 >{{title}}</h2>
-  <PrestationsContent class="mt-6 max-w-3xl" ref="prestationsRef" />
+  <PrestationsContent class="mt-6 max-w-3xl" />
 </div>
 <div class="mt-12 grid grid-cols-2 gap-0.5 md:grid-cols-3 lg:mt-0 lg:grid-cols-2">
   <div
```

Test are updated, I'll work on the doc when I'll have your feedback on that.
We can even also generate the typescript modules so frontmatter are typed!

Thanks!
Mathieu

