### PR TITLE
feat: change docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,30 @@ export default {
 
 Components under `./src/components` can be directly used in markdown components, and markdown components can also be put under `./src/components` to be auto imported.
 
+### Work with [prism-theme-vars](https://github.com/antfu/prism-theme-vars)
+
+```ts
+import Markdown from 'vite-plugin-md'
+
+export default {
+  plugins: [
+    Markdown({
+      // A function providing the Markdown It instance gets the ability to apply custom settings/plugins
+      markdownItSetup(md) {
+        // for example
+        md.use(require('markdown-it-prism'))
+      },
+    })
+  ],
+}
+```
+
+```css
+@import  'prism-theme-vars/base.css' ;
+```
+
+A customizable Prism.js theme using CSS variables. Or introduce basic style.
+
 ## TypeScript Shim
 
 ```ts


### PR DESCRIPTION
I am using this plug-in to encounter a more confusing question, because I haven't done MarkDown related features before, I use this plug-in, the MD file is correctly parsed, but there is no MarkDown style, I spent some time to see Vitesse's code discovery is not introduced in style.

Is there a consideration to add an explanation in the document, let this plugin can be better out of the box, or you can add a promotional channel for `prism-theme-vars`.

I provide a PR that may be less likely to be