### PR TITLE
fix: don't skip import IDs that have a query parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,10 @@ function VitePluginMarkdown(userOptions: Options = {}): Plugin {
     name: 'vite-plugin-md',
     enforce: 'pre',
     transform(raw, id) {
-      if (!filter(id))
+      const [filename, query] = id.split('?')
+      if (!filter(filename))
+        return
+      if (query === 'raw')
         return
       try {
         return markdownToVue(id, raw)


### PR DESCRIPTION
Currently `vite-plugin-md` doesn't transform modules that have query parameters.

This causes the new major release `vite-plugin-ssr@0.4.0` to not work with `vite-plugin-md`.

This fixes the problem.