### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ npm i vite-plugin-md -D # yarn add vite-plugin-md -D
 ### TypeScript Shim
 _where needed:_
 ```ts
-import type { ComponentOptions } from 'vue'
-
 declare module '*.vue' {
+  import type { ComponentOptions } from 'vue'
   const Component: ComponentOptions
   export default Component
 }
 
 declare module '*.md' {
+  import type { ComponentOptions } from 'vue'
   const Component: ComponentOptions
   export default Component
 }

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ npm i vite-plugin-md -D # yarn add vite-plugin-md -D
 ### TypeScript Shim
 _where needed:_
 ```ts
+import type { ComponentOptions } from 'vue'
+
 declare module '*.vue' {
-  import type { ComponentOptions, ComponentOptions } from 'vue'
   const Component: ComponentOptions
   export default Component
 }


### PR DESCRIPTION
I noticed `ComponentOptions` was duplicated and also it was missing type import for `.md` as well. Just placed it globally to avoid duplicated imports in both `declare module`.