### PR TITLE
fix: markdown relative link resolution error

### DIFF
--- a/src/builders/link/md-link.ts
+++ b/src/builders/link/md-link.ts
@@ -44,7 +44,7 @@ const plugin = (o: MdLinkOptions): PluginSimple => (
     throw new Error('link plugin requires a transform function to do it\'s job!')
   }
   else {
-    const base = normalizePath(join(o.base || '/', dirname(o.file)))
+    const base = normalizePath(join('/', o.base || dirname(o.file)))
     md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
       const link = tokens[idx]
       const original = toDictionary(link, base)

--- a/test/link-builder.test.ts
+++ b/test/link-builder.test.ts
@@ -127,7 +127,7 @@ describe('link testing', () => {
 
     for (const l of links) {
       expect(
-        l.getAttribute('to').startsWith('one'),
+        l.getAttribute('to').startsWith('/one'),
         `when we have a "base" of "one" all internal URLs should start with that URL but the URL was "${l.getAttribute('to')}"\n`,
       ).toBeTruthy()
     }
@@ -142,7 +142,7 @@ describe('link testing', () => {
 
     for (const l of links) {
       expect(
-        l.getAttribute('to').startsWith('one'),
+        l.getAttribute('to').startsWith('/one'),
         `when we have a "base" of "foo" all internal URLs should start with that URL. Url was:  ${l.getAttribute('to')}\n`,
       ).toBeTruthy()
     }


### PR DESCRIPTION
If you use a relative link to refer to a cross-directory md file, there is a missing `/` at the beginning that prevents `<RouterLink />` from jumping.

In the use of `. /go/hi.md` and `go/hi.md` can be problematic. But not with `/go/hi.md`.