### PR TITLE
docs:add usage notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ import { Counter } from './Counter.vue'
 
 Or you can use [`vite-plugin-components`](#work-with-vite-plugin-components) for auto components registration.
 
-Please pay attention to the name of the component. `kebab-case` is recommended because it meets the standard
+Please pay attention to the name of the component. `kebab-case` is recommended because it meets the standard.
 
 ## Frontmatter
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ import { Counter } from './Counter.vue'
 
 Or you can use [`vite-plugin-components`](#work-with-vite-plugin-components) for auto components registration.
 
+Please pay attention to the name of the component. `kebab-case` is recommended because it meets the standard
+
 ## Frontmatter
 
 Frontmatter will be parsed and inject into Vue's instance data `frontmatter` field.


### PR DESCRIPTION
Description should be added

> #90 Failed to use Vue component in markdown